### PR TITLE
unify core component model

### DIFF
--- a/src/composer.rs
+++ b/src/composer.rs
@@ -26,7 +26,6 @@ impl Composer {
         let socket_package_id = graph.register_package(socket_package)?;
         let plug_package_id = graph.register_package(plug_package)?;
 
-        // compose plug component into socket component
         wac_graph::plug(&mut graph, vec![plug_package_id], socket_package_id)?;
 
         let encode_options = EncodeOptions {

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -4,59 +4,73 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
-pub type CapabilityName = String;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DefinitionBase {
+    pub uri: String,
+    #[serde(default = "default_enables")]
+    pub enables: String, // "none"|"package"|"namespace"|"unexposed"|"exposed"|"any"
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ComponentDefinitionBase {
+    #[serde(flatten)]
+    base: DefinitionBase,
+    #[serde(default)]
+    pub expects: Vec<String>, // Named components this expects to be available
+    #[serde(default)]
+    pub exposed: bool,
+    pub config: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl std::ops::Deref for ComponentDefinitionBase {
+    type Target = DefinitionBase;
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RuntimeFeatureDefinition {
+    pub name: String,
+    #[serde(flatten)]
+    base: DefinitionBase,
+}
+
+impl std::ops::Deref for RuntimeFeatureDefinition {
+    type Target = DefinitionBase;
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ComponentDefinition {
-    pub uri: String,
-    pub config: Option<HashMap<String, serde_json::Value>>,
-    #[serde(default)]
-    pub capabilities: Vec<CapabilityName>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct CapabilityDefinition {
     pub name: String,
     #[serde(flatten)]
-    pub base: ComponentDefinition,
-    #[serde(default)]
-    pub exposed: bool,
+    base: ComponentDefinitionBase,
 }
 
-impl std::ops::Deref for CapabilityDefinition {
-    type Target = ComponentDefinition;
+impl std::ops::Deref for ComponentDefinition {
+    type Target = ComponentDefinitionBase;
     fn deref(&self) -> &Self::Target {
         &self.base
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ToolDefinition {
-    pub name: String,
-    #[serde(flatten)]
-    pub base: ComponentDefinition,
-}
-
-impl std::ops::Deref for ToolDefinition {
-    type Target = ComponentDefinition;
-    fn deref(&self) -> &Self::Target {
-        &self.base
+impl AsRef<DefinitionBase> for ComponentDefinition {
+    fn as_ref(&self) -> &DefinitionBase {
+        &self.base.base
     }
 }
 
-/// Load capability and tool definitions from configuration files
-///
-/// Processes capability files (.toml), tool files (.toml), and mixed definition files
-/// (.toml and .wasm) to extract component definitions.
+/// Load component definitions from configuration files
 pub fn load_definitions(
-    capability_files: &[PathBuf],
-    tool_files: &[PathBuf],
-    mixed_definition_files: &[PathBuf], // .toml and .wasm files
-) -> Result<(Vec<CapabilityDefinition>, Vec<ToolDefinition>)> {
-    let mut definition_files = Vec::new();
+    definition_files: &[PathBuf], // .toml and .wasm files
+) -> Result<(Vec<RuntimeFeatureDefinition>, Vec<ComponentDefinition>)> {
+    let mut toml_files = Vec::new();
     let mut wasm_files = Vec::new();
 
-    for path in mixed_definition_files {
+    for path in definition_files {
         let path_str = path.to_string_lossy();
 
         // Handle OCI URIs as wasm components
@@ -65,7 +79,7 @@ pub fn load_definitions(
         } else if let Some(extension) = path.extension().and_then(|s| s.to_str()) {
             match extension {
                 "wasm" => wasm_files.push(path.clone()),
-                "toml" => definition_files.push(path.clone()),
+                "toml" => toml_files.push(path.clone()),
                 _ => return Err(anyhow::anyhow!("Unsupported file type: {}", path.display())),
             }
         } else {
@@ -75,193 +89,205 @@ pub fn load_definitions(
             ));
         }
     }
-    build_definitions(capability_files, tool_files, &definition_files, &wasm_files)
+    build_definitions(&toml_files, &wasm_files)
 }
 
 fn build_definitions(
-    capability_files: &[PathBuf],
-    tool_files: &[PathBuf],
-    definition_files: &[PathBuf],
+    toml_files: &[PathBuf],
     wasm_files: &[PathBuf],
-) -> Result<(Vec<CapabilityDefinition>, Vec<ToolDefinition>)> {
-    let mut capability_definitions = Vec::new();
-    let mut tool_definitions = Vec::new();
+) -> Result<(Vec<RuntimeFeatureDefinition>, Vec<ComponentDefinition>)> {
+    let mut runtime_feature_definitions = Vec::new();
+    let mut component_definitions = Vec::new();
 
-    for file in capability_files {
-        capability_definitions.extend(parse_capability_file(file)?);
+    // Parse TOML files to extract both runtime features and components
+    for file in toml_files {
+        let (runtime_features, components) = parse_toml_file(file)?;
+        runtime_feature_definitions.extend(runtime_features);
+        component_definitions.extend(components);
     }
-    for file in tool_files {
-        tool_definitions.extend(parse_tool_file(file)?);
-    }
-    for file in definition_files {
-        let (caps, tools) = parse_definition_file(file)?;
-        capability_definitions.extend(caps);
-        tool_definitions.extend(tools);
-    }
-    tool_definitions.extend(create_implicit_tool_definitions(wasm_files)?);
 
-    // Collision detection for capabilities
-    let mut capability_names = HashSet::new();
-    for def in &capability_definitions {
-        if !capability_names.insert(&def.name) {
-            return Err(anyhow::anyhow!("Duplicate capability name: '{}'", def.name));
+    // Add implicit component definitions from standalone .wasm files
+    component_definitions.extend(create_implicit_component_definitions(wasm_files)?);
+
+    for def in &runtime_feature_definitions {
+        validate_runtime_feature_enables_scope(&def.enables, &def.name)?;
+    }
+    for def in &component_definitions {
+        validate_component_enables_scope(&def.enables)?;
+    }
+
+    // Collision detection - ensure unique names across all definitions
+    let mut all_names = HashSet::new();
+    for def in &runtime_feature_definitions {
+        if !all_names.insert(&def.name) {
+            return Err(anyhow::anyhow!("Duplicate definition name: '{}'", def.name));
+        }
+    }
+    for def in &component_definitions {
+        if !all_names.insert(&def.name) {
+            return Err(anyhow::anyhow!("Duplicate definition name: '{}'", def.name));
         }
     }
 
-    // Validate capability dependencies exist
-    for def in &capability_definitions {
-        for dep_name in &def.capabilities {
-            if !capability_names.contains(dep_name) {
-                return Err(anyhow::anyhow!(
-                    "Capability '{}' depends on undefined capability '{}'",
-                    def.name,
-                    dep_name
-                ));
+    // Validate component expectations - different error handling based on exposed flag
+    for def in &component_definitions {
+        for expected_name in &def.expects {
+            if !all_names.contains(expected_name) {
+                if def.exposed {
+                    continue;
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Component '{}' expects undefined definition '{}' - server cannot start",
+                        def.name,
+                        expected_name
+                    ));
+                }
             }
         }
     }
 
-    // Collision detection for tools
-    let mut tool_names = HashSet::new();
-    for def in &tool_definitions {
-        if !tool_names.insert(&def.name) {
-            return Err(anyhow::anyhow!("Duplicate tool name: '{}'", def.name));
-        }
+    Ok((runtime_feature_definitions, component_definitions))
+}
+
+fn default_enables() -> String {
+    "none".to_string()
+}
+
+fn validate_runtime_feature_enables_scope(enables: &str, name: &str) -> Result<()> {
+    match enables {
+        "none" | "unexposed" | "exposed" | "any" => Ok(()),
+        "package" | "namespace" => Err(anyhow::anyhow!(
+            "RuntimeFeature '{}' cannot use enables='{}' - only components support package/namespace scoping",
+            name,
+            enables
+        )),
+        _ => Err(anyhow::anyhow!(
+            "Invalid enables scope: '{}'. Must be one of: none, unexposed, exposed, any",
+            enables
+        )),
     }
-    for capability_name in &capability_names {
-        if tool_names.contains(capability_name) {
-            return Err(anyhow::anyhow!(
-                "Name collision: '{}' is defined as both a capability and a tool",
-                capability_name
-            ));
-        }
+}
+
+fn validate_component_enables_scope(enables: &str) -> Result<()> {
+    match enables {
+        "none" | "package" | "namespace" | "unexposed" | "exposed" | "any" => Ok(()),
+        _ => Err(anyhow::anyhow!(
+            "Invalid enables scope: '{}'. Must be one of: none, package, namespace, unexposed, exposed, any",
+            enables
+        )),
     }
-
-    Ok((capability_definitions, tool_definitions))
 }
 
-fn parse_capability_file(path: &PathBuf) -> Result<Vec<CapabilityDefinition>> {
-    let content = fs::read_to_string(path)?;
-    let toml_doc: toml::Value = toml::from_str(&content)?;
-    parse_capabilities_from_toml(&toml_doc)
-}
-
-fn parse_tool_file(path: &PathBuf) -> Result<Vec<ToolDefinition>> {
-    let content = fs::read_to_string(path)?;
-    let toml_doc: toml::Value = toml::from_str(&content)?;
-    parse_tools_from_toml(&toml_doc)
-}
-
-fn parse_definition_file(
+fn parse_toml_file(
     path: &PathBuf,
-) -> Result<(Vec<CapabilityDefinition>, Vec<ToolDefinition>)> {
+) -> Result<(Vec<RuntimeFeatureDefinition>, Vec<ComponentDefinition>)> {
     let content = fs::read_to_string(path)?;
     let toml_doc: toml::Value = toml::from_str(&content)?;
 
-    let (caps_section, tools_section) = split_namespaced_toml(&toml_doc);
+    let mut runtime_features = Vec::new();
+    let mut components = Vec::new();
 
-    let capabilities = if let Some(section) = caps_section {
-        parse_capabilities_from_toml(section)?
-    } else {
-        Vec::new()
-    };
-
-    let tools = if let Some(section) = tools_section {
-        parse_tools_from_toml(section)?
-    } else {
-        Vec::new()
-    };
-
-    // If no namespaced sections found, check if there are top-level sections that might be tools
-    if capabilities.is_empty() && tools.is_empty() {
-        if let toml::Value::Table(table) = &toml_doc {
-            if !table.is_empty() {
-                return Err(anyhow::anyhow!(
-                    "No [capabilities.*] or [tools.*] sections found in '{}', but found top-level sections. Use the -t flag if it is a tool definition file.",
-                    path.display()
-                ));
-            }
-        }
-    }
-
-    Ok((capabilities, tools))
-}
-
-fn split_namespaced_toml(toml_doc: &toml::Value) -> (Option<&toml::Value>, Option<&toml::Value>) {
     if let toml::Value::Table(table) = toml_doc {
-        let capabilities_section = table.get("capabilities");
-        let tools_section = table.get("tools");
-        (capabilities_section, tools_section)
-    } else {
-        (None, None)
-    }
-}
-
-fn parse_capabilities_from_toml(
-    capabilities_section: &toml::Value,
-) -> Result<Vec<CapabilityDefinition>> {
-    let mut definitions = Vec::new();
-    if let toml::Value::Table(table) = capabilities_section {
         for (name, value) in table {
-            if let toml::Value::Table(capability_table) = value {
-                let definition = parse_capability_toml_table(name, capability_table)?;
-                definitions.push(definition);
+            if let toml::Value::Table(def_table) = value {
+                // Check if this is a runtime feature (wasmtime:*) or component
+                if let Some(uri) = def_table.get("uri").and_then(|v| v.as_str()) {
+                    if uri.starts_with("wasmtime:") {
+                        let definition_base: DefinitionBase =
+                            toml::Value::Table(def_table).try_into().map_err(|e| {
+                                anyhow::anyhow!("Failed to parse runtime feature '{}': {}", name, e)
+                            })?;
+                        runtime_features.push(RuntimeFeatureDefinition {
+                            name: name.clone(),
+                            base: definition_base,
+                        });
+                    } else {
+                        let mut definition_value = def_table.clone();
+                        let config = if let Some(toml::Value::Table(config_table)) =
+                            definition_value.remove("config")
+                        {
+                            Some(convert_toml_table_to_json_map(&config_table)?)
+                        } else {
+                            None
+                        };
+
+                        let mut component_base: ComponentDefinitionBase =
+                            toml::Value::Table(definition_value)
+                                .try_into()
+                                .map_err(|e| {
+                                    anyhow::anyhow!("Failed to parse component '{}': {}", name, e)
+                                })?;
+
+                        component_base.config = config;
+                        components.push(ComponentDefinition {
+                            name: name.clone(),
+                            base: component_base,
+                        });
+                    }
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Definition '{}' missing required 'uri' field",
+                        name
+                    ));
+                }
+            } else {
+                return Err(anyhow::anyhow!("Definition '{}' must be a table", name));
             }
         }
-    }
-    Ok(definitions)
-}
-
-fn parse_tools_from_toml(tools_section: &toml::Value) -> Result<Vec<ToolDefinition>> {
-    let mut definitions = Vec::new();
-    if let toml::Value::Table(table) = tools_section {
-        for (name, value) in table {
-            if let toml::Value::Table(tool_table) = value {
-                let component = parse_component_toml_table(name, tool_table)?;
-                let definition = ToolDefinition {
-                    name: name.to_string(),
-                    base: component,
-                };
-                definitions.push(definition);
-            }
-        }
-    }
-    Ok(definitions)
-}
-
-fn parse_capability_toml_table(
-    name: &str,
-    table: &toml::map::Map<String, toml::Value>,
-) -> Result<CapabilityDefinition> {
-    let component = parse_component_toml_table(name, table)?;
-    let exposed = table
-        .get("exposed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    Ok(CapabilityDefinition {
-        name: name.to_string(),
-        base: component,
-        exposed,
-    })
-}
-
-fn parse_component_toml_table(
-    name: &str,
-    table: &toml::map::Map<String, toml::Value>,
-) -> Result<ComponentDefinition> {
-    let mut definition_value = table.clone();
-    let config = if let Some(toml::Value::Table(config_table)) = definition_value.remove("config") {
-        Some(convert_toml_table_to_json_map(&config_table)?)
     } else {
-        None
-    };
+        return Err(anyhow::anyhow!(
+            "TOML file must contain a table at root level"
+        ));
+    }
+    Ok((runtime_features, components))
+}
 
-    let mut component: ComponentDefinition = toml::Value::Table(definition_value)
-        .try_into()
-        .map_err(|e| anyhow::anyhow!("Failed to parse component '{}': {}", name, e))?;
+fn create_implicit_component_definitions(
+    wasm_files: &[PathBuf],
+) -> Result<Vec<ComponentDefinition>> {
+    let mut definitions = Vec::new();
+    for path in wasm_files {
+        let path_str = path.to_string_lossy();
+        let name = if path_str.starts_with("oci://") {
+            // Extract component name from OCI URI: oci://ghcr.io/modulewise/hello:0.1.0 -> hello
+            let oci_ref = path_str.strip_prefix("oci://").unwrap();
+            if let Some((pkg_part, _version)) = oci_ref.rsplit_once(':') {
+                if let Some(name_part) = pkg_part.rsplit_once('/') {
+                    name_part.1.to_string()
+                } else {
+                    pkg_part.to_string()
+                }
+            } else {
+                return Err(anyhow::anyhow!("Invalid OCI URI format: {}", path_str));
+            }
+        } else {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Cannot extract component name from path: {}",
+                        path.display()
+                    )
+                })?
+                .to_string()
+        };
 
-    component.config = config;
-    Ok(component)
+        // Implicit components from .wasm files are treated as exposed components
+        let definition = ComponentDefinition {
+            name,
+            base: ComponentDefinitionBase {
+                base: DefinitionBase {
+                    uri: path.to_string_lossy().to_string(),
+                    enables: default_enables(),
+                },
+                expects: Vec::new(),
+                exposed: true,
+                config: None,
+            },
+        };
+        definitions.push(definition);
+    }
+    Ok(definitions)
 }
 
 fn convert_toml_table_to_json_map(
@@ -295,44 +321,4 @@ fn convert_toml_value_to_json(value: &toml::Value) -> Result<serde_json::Value> 
         }
         toml::Value::Datetime(dt) => Ok(serde_json::Value::String(dt.to_string())),
     }
-}
-
-fn create_implicit_tool_definitions(wasm_files: &[PathBuf]) -> Result<Vec<ToolDefinition>> {
-    let mut definitions = Vec::new();
-    for path in wasm_files {
-        let path_str = path.to_string_lossy();
-        let name = if path_str.starts_with("oci://") {
-            // Extract component name from OCI URI: oci://ghcr.io/modulewise/hello:0.1.0 -> hello
-            let oci_ref = path_str.strip_prefix("oci://").unwrap();
-            if let Some((pkg_part, _version)) = oci_ref.rsplit_once(':') {
-                if let Some(name_part) = pkg_part.rsplit_once('/') {
-                    name_part.1.to_string()
-                } else {
-                    pkg_part.to_string()
-                }
-            } else {
-                return Err(anyhow::anyhow!("Invalid OCI URI format: {}", path_str));
-            }
-        } else {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Cannot extract component name from path: {}",
-                        path.display()
-                    )
-                })?
-                .to_string()
-        };
-        let definition = ToolDefinition {
-            name,
-            base: ComponentDefinition {
-                uri: path.to_string_lossy().to_string(),
-                config: None,
-                capabilities: Vec::new(),
-            },
-        };
-        definitions.push(definition);
-    }
-    Ok(definitions)
 }


### PR DESCRIPTION
There is no longer a distinction between Capability definitions and Tool definitions. Rather all definitions are simply for Components if not runtime feature definitions (currently only those with a "wasmtime:" prefix). Any Component can be surfaced as a Tool for the MCP Server if its `exposed` property is set to `true`. Any Component can specify that it "enables" other Components within a given scope: `none`, `package`, `namespace`, `unexposed` (internal-only), `exposed`, or `any`. Even if a Component is itself exposed as a Tool, it can now also be an enabling Component for others. That was not possible with the firm Capability vs Tool distinction in the previous model.

resolves #19 